### PR TITLE
Add copy functionality to analysis modal

### DIFF
--- a/app/src/main/res/layout/dialog_conversation_analysis.xml
+++ b/app/src/main/res/layout/dialog_conversation_analysis.xml
@@ -38,7 +38,9 @@
                 android:background="?attr/selectableItemBackgroundBorderless"
                 android:padding="12dp"
                 android:contentDescription="Copy analysis"
-                android:tint="@color/md_theme_primary"/>
+                android:tint="@color/md_theme_primary"
+                android:clickable="true"
+                android:focusable="true"/>
         </RelativeLayout>
 
         <TextView
@@ -48,7 +50,8 @@
             android:textSize="14sp"
             android:textColor="?android:textColorSecondary"
             android:layout_marginBottom="24dp"
-            android:fontFamily="@font/roboto"/>
+            android:fontFamily="@font/roboto"
+            android:textIsSelectable="true"/>
 
         <TextView
             android:layout_width="match_parent"
@@ -58,7 +61,8 @@
             android:textStyle="bold"
             android:textColor="@color/md_theme_primary"
             android:layout_marginBottom="8dp"
-            android:fontFamily="@font/roboto_medium"/>
+            android:fontFamily="@font/roboto_medium"
+            android:textIsSelectable="true"/>
 
         <TextView
             android:id="@+id/analysisNextSteps"
@@ -68,7 +72,8 @@
             android:textColor="@color/md_theme_onBackground"
             android:lineSpacingMultiplier="1.4"
             android:layout_marginBottom="32dp"
-            android:fontFamily="@font/roboto"/>
+            android:fontFamily="@font/roboto"
+            android:textIsSelectable="true"/>
 
         <TextView
             android:layout_width="match_parent"
@@ -78,7 +83,8 @@
             android:textStyle="bold"
             android:textColor="@color/md_theme_primary"
             android:layout_marginBottom="8dp"
-            android:fontFamily="@font/roboto_medium"/>
+            android:fontFamily="@font/roboto_medium"
+            android:textIsSelectable="true"/>
 
         <TextView
             android:id="@+id/analysisFollowup"
@@ -88,7 +94,8 @@
             android:textColor="@color/md_theme_onBackground"
             android:lineSpacingMultiplier="1.4"
             android:layout_marginBottom="32dp"
-            android:fontFamily="@font/roboto"/>
+            android:fontFamily="@font/roboto"
+            android:textIsSelectable="true"/>
 
         <TextView
             android:layout_width="match_parent"
@@ -98,7 +105,8 @@
             android:textStyle="bold"
             android:textColor="@color/md_theme_primary"
             android:layout_marginBottom="8dp"
-            android:fontFamily="@font/roboto_medium"/>
+            android:fontFamily="@font/roboto_medium"
+            android:textIsSelectable="true"/>
 
         <TextView
             android:id="@+id/analysisNegotiation"
@@ -108,7 +116,8 @@
             android:textColor="@color/md_theme_onBackground"
             android:lineSpacingMultiplier="1.4"
             android:layout_marginBottom="32dp"
-            android:fontFamily="@font/roboto"/>
+            android:fontFamily="@font/roboto"
+            android:textIsSelectable="true"/>
 
         <TextView
             android:layout_width="match_parent"
@@ -118,7 +127,8 @@
             android:textStyle="bold"
             android:textColor="@color/md_theme_primary"
             android:layout_marginBottom="8dp"
-            android:fontFamily="@font/roboto_medium"/>
+            android:fontFamily="@font/roboto_medium"
+            android:textIsSelectable="true"/>
 
         <TextView
             android:id="@+id/analysisSuggestedReply"
@@ -129,7 +139,8 @@
             android:textStyle="italic"
             android:lineSpacingMultiplier="1.4"
             android:layout_marginBottom="24dp"
-            android:fontFamily="@font/roboto"/>
+            android:fontFamily="@font/roboto"
+            android:textIsSelectable="true"/>
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/reAnalyzeButton"


### PR DESCRIPTION
Add text selection and copy functionality to the analysis modal.

* Set `android:textIsSelectable` to `true` for all `TextView` elements in `dialog_conversation_analysis.xml`.
* Add `android:clickable` and `android:focusable` attributes to `copyButton` in `dialog_conversation_analysis.xml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abdul977/whatsuit/pull/5?shareId=f5a1db2b-c979-4df8-b876-9fbc6885b4bc).