### PR TITLE
Fix multiple replies issue in NotificationService

### DIFF
--- a/app/src/main/java/com/example/whatsuit/NotificationService.java
+++ b/app/src/main/java/com/example/whatsuit/NotificationService.java
@@ -488,6 +488,11 @@ long id;
     }
 
     private void generateAndSendReply(NotificationEntity notification, Notification.Action replyAction) {
+        if (notification.isAutoReplied()) {
+            Log.d(TAG, "Notification already auto-replied, skipping: " + notification.getId());
+            return;
+        }
+
         geminiService.generateReply(notification.getId(), notification.getContent(), new GeminiService.ResponseCallback() {
             @Override
             public void onPartialResponse(String text) {


### PR DESCRIPTION
Add a check to prevent multiple replies for the same notification.

* Add a check in `generateAndSendReply` to skip sending a reply if the notification has already been auto-replied.
* Log a message when a notification is skipped due to already being auto-replied.

