### PR TITLE
Fix unresolved references in NotificationsFragment

### DIFF
--- a/app/src/main/java/com/example/whatsuit/fragment/NotificationsFragment.kt
+++ b/app/src/main/java/com/example/whatsuit/fragment/NotificationsFragment.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.whatsuit.R
 import com.example.whatsuit.adapter.RelatedNotificationsAdapter
 import com.example.whatsuit.viewmodel.NotificationDetailViewModel
+import androidx.fragment.app.viewModels
 
 class NotificationsFragment : Fragment() {
     private lateinit var recyclerView: RecyclerView

--- a/app/src/main/res/layout/fragment_notifications.xml
+++ b/app/src/main/res/layout/fragment_notifications.xml
@@ -25,4 +25,23 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/appHeaderChipGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/relatedNotificationsRecyclerView">
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/chipAllApps"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="All Apps"
+            app:chipBackgroundColor="@color/md_theme_onPrimary"
+            android:checkable="true"
+            android:checked="true" />
+    </com.google.android.material.chip.ChipGroup>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Resolve compilation errors in `NotificationsFragment.kt` and update layout file `fragment_notifications.xml`.

* Import `import androidx.fragment.app.viewModels` in `NotificationsFragment.kt` to resolve `viewModels` reference.
* Add `appHeaderChipGroup` and `chipAllApps` to `fragment_notifications.xml` to resolve unresolved references.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abdul977/whatsuit/pull/19?shareId=96968766-b4ac-4063-820e-c0ad3337018a).